### PR TITLE
Support the use of specifying a HA Entity ID and Friendly Name

### DIFF
--- a/Supporting_a_New_Device.md
+++ b/Supporting_a_New_Device.md
@@ -270,7 +270,7 @@ def handle_GVH5183(value, trigger, msg)
           output_map['Temperature_Target'] = round(this_data[1]/100.0, this_device['temp_precision'])
           output_map['Temperature_Calibration_C'] = round(this_data[2]/100.0, this_device['temp_precision'])
           output_map['Temperature_Calibration_F'] = round(this_data[2]/100.0*1.8, this_device['temp_precision'])
-          var this_topic = base_topic + '/' + this_device['alias']
+          var this_topic = base_topic + '/' + this_device['entity_id']
           tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
           if this_device['publish_attributes']
             for output_key:output_map.keys()

--- a/blerry/blerry.be
+++ b/blerry/blerry.be
@@ -9,15 +9,16 @@
 
 # --------- USER INPUT ---------
 # user_config map (mac and config options pairs)
-#   alias               REQUIRED                        name you are assigning the device
-#   model               OPTIONAL (default = 'ATCpvvx')  BLE device model to associate with mac
-#   discovery           OPTIONAL (default = false)      publish HA MQTT discovery payloads
-#   use_lwt             OPTIONAL (default = false)      use LWT for availability in discovery payloads (discovery packet also include 600s timeout of sensor data)
-#   via_pubs            OPTIONAL (default = false)      publish Time_via_%topic% and RSSI_via_%topic% data with each data set
-#   sensor_retain       OPTIONAL (default = false)      add retain flag to sensor data set publishes
-#   publish_attributes  OPTIONAL (default = false)      publish individual topics for each attribute in addition to the JSON payload
-#   temp_precision      OPTIONAL (default = 2, int)     digits of precision for temperature
-#   humi_precision      OPTIONAL (default = 1, int)     digits of precision for humidity
+#   alias               REQUIRED                            name you are assigning the device
+#   entity_id           OPTIONAL (default = modified alias) Entity ID to assign the device in HA. If not specified, it will be derived from the alias (spaces replaced with underscores and all lowercase)
+#   model               OPTIONAL (default = 'ATCpvvx')      BLE device model to associate with mac
+#   discovery           OPTIONAL (default = false)          publish HA MQTT discovery payloads
+#   use_lwt             OPTIONAL (default = false)          use LWT for availability in discovery payloads (discovery packet also include 600s timeout of sensor data)
+#   via_pubs            OPTIONAL (default = false)          publish Time_via_%topic% and RSSI_via_%topic% data with each data set
+#   sensor_retain       OPTIONAL (default = false)          add retain flag to sensor data set publishes
+#   publish_attributes  OPTIONAL (default = false)          publish individual topics for each attribute in addition to the JSON payload
+#   temp_precision      OPTIONAL (default = 2, int)         digits of precision for temperature
+#   humi_precision      OPTIONAL (default = 1, int)         digits of precision for humidity
 var user_config = {
                    'A4C138AAAAAA': {'alias': 'trial_govee5075', 'model': 'GVH5075', 'discovery': true},
                    'A4C138BBBBBB': {'alias': 'other_govee5075', 'model': 'GVH5075', 'via_pubs': false},
@@ -27,7 +28,7 @@ var user_config = {
                    'C33130XXXXXX/1': {'alias': 'govee5182-2probe-meats', 'model': 'GVH5182'},
                    'A4C138XXXXXX': {'alias': 'govee5183meats', 'model': 'GVH5183'},
                    'D03232XXXXXX/1': {'alias': 'govee5184-4probe-meats', 'model': 'GVH5184'},
-                   'A4C138CCCCCC': {'alias': 'trial_ATCpvvx', 'model': 'ATCpvvx', 'discovery': true, 'use_lwt': true},
+                   'A4C138CCCCCC': {'alias': 'ATCpvvx Shower', 'entity_id': 'atcpvvx_shower',  'model': 'ATCpvvx', 'discovery': true, 'use_lwt': true},
                    'A4C138CCCCCC': {'alias': 'ATC_on_milike', 'model': 'ATCmi'},
                    '494208DDDDDD': {'alias': 'trial_inkbird', 'model': 'IBSTH2', 'discovery': true},
                    'D4E4A3BBBBBB/1': {'alias': 'sbot_TH', 'model': 'WoSensorTH'},

--- a/blerry/blerry_main.be
+++ b/blerry/blerry_main.be
@@ -62,9 +62,9 @@ def publish_sensor_discovery(mac, prop, dclass, unitm)
   else
     prefix = prefix + '\"avty\": [],'
   end
-  prefix = prefix + string.format('\"dev\":{\"ids\":[\"blerry_%s\"],\"name\":\"%s\",\"mf\":\"blerry\",\"mdl\":\"%s\",\"via_device\":\"%s\"},', item['alias'], item['alias'], item['model'], hostname)
-  prefix = prefix + string.format('\"exp_aft\": 600,\"json_attr_t\": \"%s/%s\",\"stat_t\": \"%s/%s\",', base_topic, item['alias'], base_topic, item['alias'])
-  tasmota.publish(string.format('homeassistant/sensor/blerry_%s/%s/config', item['alias'], prop), prefix + string.format('\"dev_cla\": \"%s\",\"unit_of_meas\": \"%s\",\"name\": \"%s %s\",\"uniq_id\": \"blerry_%s_%s\",\"val_tpl\": \"{{ value_json.%s }}\"}', dclass, unitm, item['alias'], prop, item['alias'], prop, prop), discovery_retain)
+  prefix = prefix + string.format('\"dev\":{\"ids\":[\"blerry_%s\"],\"name\":\"%s\",\"mf\":\"blerry\",\"mdl\":\"%s\",\"via_device\":\"%s\"},', item['entity_id'], item['alias'], item['model'], hostname)
+  prefix = prefix + string.format('\"exp_aft\": 600,\"json_attr_t\": \"%s/%s\",\"stat_t\": \"%s/%s\",', base_topic, item['entity_id'], base_topic, item['entity_id'])
+  tasmota.publish(string.format('homeassistant/sensor/blerry_%s/%s/config', item['entity_id'], prop), prefix + string.format('\"dev_cla\": \"%s\",\"unit_of_meas\": \"%s\",\"name\": \"%s %s\",\"uniq_id\": \"blerry_%s_%s\",\"val_tpl\": \"{{ value_json.%s }}\"}', dclass, unitm, item['alias'], prop, item['entity_id'], prop, prop), discovery_retain)
 end
 
 def publish_binary_sensor_discovery(mac, prop, dclass)
@@ -75,12 +75,12 @@ def publish_binary_sensor_discovery(mac, prop, dclass)
   else
     prefix = prefix + '\"avty\": [],'
   end
-  prefix = prefix + string.format('\"dev\":{\"ids\":[\"blerry_%s\"],\"name\":\"%s\",\"mf\":\"blerry\",\"mdl\":\"%s\",\"via_device\":\"%s\"},', item['alias'], item['alias'], item['model'], hostname)
-  prefix = prefix + string.format('\"exp_aft\": 600,\"json_attr_t\": \"%s/%s\",\"stat_t\": \"%s/%s\",', base_topic, item['alias'], base_topic, item['alias'])
+  prefix = prefix + string.format('\"dev\":{\"ids\":[\"blerry_%s\"],\"name\":\"%s\",\"mf\":\"blerry\",\"mdl\":\"%s\",\"via_device\":\"%s\"},', item['entity_id'], item['alias'], item['model'], hostname)
+  prefix = prefix + string.format('\"exp_aft\": 600,\"json_attr_t\": \"%s/%s\",\"stat_t\": \"%s/%s\",', base_topic, item['entity_id'], base_topic, item['entity_id'])
   if dclass != 'none'
     prefix = prefix + string.format('\"dev_cla\": \"%s\",', dclass)
   end
-  tasmota.publish(string.format('homeassistant/binary_sensor/blerry_%s/%s/config', item['alias'], prop), prefix + string.format('\"name\": \"%s %s\",\"uniq_id\": \"blerry_%s_%s\",\"val_tpl\": \"{{ value_json.%s }}\"}', item['alias'], prop, item['alias'], prop, prop), discovery_retain)
+  tasmota.publish(string.format('homeassistant/binary_sensor/blerry_%s/%s/config', item['entity_id'], prop), prefix + string.format('\"name\": \"%s %s\",\"uniq_id\": \"blerry_%s_%s\",\"val_tpl\": \"{{ value_json.%s }}\"}', item['alias'], prop, item['entity_id'], prop, prop), discovery_retain)
 end
 
 # Build complete device config maps
@@ -94,10 +94,16 @@ for mac:user_config.keys()
   device_config[mac]['last_p'] = bytes('')
   device_config[mac]['done_disc'] = false
   device_config[mac]['done_extra_disc'] = false
+  device_config[mac]['entity_id'] = ''
 
   # override with device specific config
   for item:user_config[mac].keys()
     device_config[mac][item] = user_config[mac][item]
+  end
+
+  # derive unique id from alias if not specified by user
+  if device_config[mac]['entity_id'] == ''
+    device_config[mac]['entity_id'] = string.tolower(string_replace(user_config[mac]['alias'], " ", "_"))
   end
 
   # override with global override
@@ -139,7 +145,7 @@ end
 var setup_active = false
 for mac:user_config.keys()
   device_config[mac]['handle'] = device_handles[device_config[mac]['model']]
-  tasmota.cmd(string.format('BLEAlias %s=%s', mac, device_config[mac]['alias']))
+  tasmota.cmd(string.format('BLEAlias %s=%s', mac, device_config[mac]['entity_id']))
   setup_active = setup_active || require_active[device_config[mac]['model']]
 end
 if setup_active

--- a/blerry/blerry_model_ATCmi.be
+++ b/blerry/blerry_model_ATCmi.be
@@ -58,7 +58,7 @@ def handle_ATCmi(value, trigger, msg)
         output_map['DewPoint'] = round(get_dewpoint(output_map['Temperature'], output_map['Humidity']), this_device['temp_precision'])
         output_map['Temperature'] = round(output_map['Temperature'], this_device['temp_precision'])
         output_map['Humidity'] = round(output_map['Humidity'], this_device['humi_precision'])
-        var this_topic = base_topic + '/' + this_device['alias']
+        var this_topic = base_topic + '/' + this_device['entity_id']
         tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
         if this_device['publish_attributes']
           for output_key:output_map.keys()

--- a/blerry/blerry_model_ATCpvvx.be
+++ b/blerry/blerry_model_ATCpvvx.be
@@ -85,7 +85,7 @@ def handle_ATCpvvx(value, trigger, msg)
           output_map['DewPoint'] = round(get_dewpoint(output_map['Temperature'], output_map['Humidity']), this_device['temp_precision'])
           output_map['Temperature'] = round(output_map['Temperature'], this_device['temp_precision'])
           output_map['Humidity'] = round(output_map['Humidity'], this_device['humi_precision'])
-          var this_topic = base_topic + '/' + this_device['alias']
+          var this_topic = base_topic + '/' + this_device['entity_id']
           tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
           if this_device['publish_attributes']
             for output_key:output_map.keys()

--- a/blerry/blerry_model_GVH5074.be
+++ b/blerry/blerry_model_GVH5074.be
@@ -47,7 +47,7 @@ def handle_GVH5074(value, trigger, msg)
           output_map['DewPoint'] = round(get_dewpoint(output_map['Temperature'], output_map['Humidity']), this_device['temp_precision'])
           output_map['Temperature'] = round(output_map['Temperature'], this_device['temp_precision'])
           output_map['Humidity'] = round(output_map['Humidity'], this_device['humi_precision'])
-          var this_topic = base_topic + '/' + this_device['alias']
+          var this_topic = base_topic + '/' + this_device['entity_id']
           tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
 
           if this_device['publish_attributes']

--- a/blerry/blerry_model_GVH5075.be
+++ b/blerry/blerry_model_GVH5075.be
@@ -55,7 +55,7 @@ def handle_GVH5075(value, trigger, msg)
         output_map['DewPoint'] = round(get_dewpoint(output_map['Temperature'], output_map['Humidity']), this_device['temp_precision'])
         output_map['Temperature'] = round(output_map['Temperature'], this_device['temp_precision'])
         output_map['Humidity'] = round(output_map['Humidity'], this_device['humi_precision'])
-        var this_topic = base_topic + '/' + this_device['alias']
+        var this_topic = base_topic + '/' + this_device['entity_id']
         tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
         if this_device['publish_attributes']
           for output_key:output_map.keys()

--- a/blerry/blerry_model_GVH5182.be
+++ b/blerry/blerry_model_GVH5182.be
@@ -59,7 +59,7 @@ def handle_GVH5182(value, trigger, msg)
             else
               output_map['Temperature_2_Target'] = round(this_data[4]/100.0, this_device['temp_precision'])
             end
-            var this_topic = base_topic + '/' + this_device['alias']
+            var this_topic = base_topic + '/' + this_device['entity_id']
             tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
             if this_device['publish_attributes']
               for output_key:output_map.keys()

--- a/blerry/blerry_model_GVH5183.be
+++ b/blerry/blerry_model_GVH5183.be
@@ -47,7 +47,7 @@ def handle_GVH5183(value, trigger, msg)
           output_map['Temperature_Target'] = round(this_data[2]/100.0, this_device['temp_precision'])
           output_map['Temperature_Calibration_C'] = round(this_data[3]/100.0, this_device['temp_precision'])
           output_map['Temperature_Calibration_F'] = round(this_data[3]/100.0*1.8, this_device['temp_precision'])
-          var this_topic = base_topic + '/' + this_device['alias']
+          var this_topic = base_topic + '/' + this_device['entity_id']
           tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
           if this_device['publish_attributes']
             for output_key:output_map.keys()

--- a/blerry/blerry_model_GVH5184.be
+++ b/blerry/blerry_model_GVH5184.be
@@ -83,7 +83,7 @@ def handle_GVH5184(value, trigger, msg)
             output_map['Temperature_'+str(j+k)+'_Target'] = probeset[3]
           end
         end
-        var this_topic = base_topic + '/' + this_device['alias']
+        var this_topic = base_topic + '/' + this_device['entity_id']
         tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
         if this_device['publish_attributes']
           for output_key:output_map.keys()

--- a/blerry/blerry_model_IBSTH2.be
+++ b/blerry/blerry_model_IBSTH2.be
@@ -48,7 +48,7 @@ def handle_IBSTH2(value, trigger, msg)
           output_map['Humidity'] = round(output_map['Humidity'], this_device['humi_precision'])
         end
         output_map['Temperature'] = round(output_map['Temperature'], this_device['temp_precision'])
-        var this_topic = base_topic + '/' + this_device['alias']
+        var this_topic = base_topic + '/' + this_device['entity_id']
         tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
         if this_device['publish_attributes']
           for output_key:output_map.keys()

--- a/blerry/blerry_model_WoContact.be
+++ b/blerry/blerry_model_WoContact.be
@@ -73,7 +73,7 @@ def handle_WoContact(value, trigger, msg)
         else
           output_map['Button'] = 'OFF'
         end
-        var this_topic = base_topic + '/' + this_device['alias']
+        var this_topic = base_topic + '/' + this_device['entity_id']
         tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
         if this_device['publish_attributes']
           for output_key:output_map.keys()

--- a/blerry/blerry_model_WoPresence.be
+++ b/blerry/blerry_model_WoPresence.be
@@ -53,7 +53,7 @@ def handle_WoPresence(value, trigger, msg)
         elif this_data[2] == 1
           output_map['Lux'] = 'OFF'
         end
-        var this_topic = base_topic + '/' + this_device['alias']
+        var this_topic = base_topic + '/' + this_device['entity_id']
         tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
         if this_device['publish_attributes']
           for output_key:output_map.keys()

--- a/blerry/blerry_model_WoSensorTH.be
+++ b/blerry/blerry_model_WoSensorTH.be
@@ -46,7 +46,7 @@ def handle_WoSensorTH(value, trigger, msg)
         output_map['DewPoint'] = round(get_dewpoint(output_map['Temperature'], output_map['Humidity']), this_device['temp_precision'])
         output_map['Temperature'] = round(output_map['Temperature'], this_device['temp_precision'])
         output_map['Humidity'] = round(output_map['Humidity'], this_device['humi_precision'])
-        var this_topic = base_topic + '/' + this_device['alias']
+        var this_topic = base_topic + '/' + this_device['entity_id']
         tasmota.publish(this_topic, json.dump(output_map), this_device['sensor_retain'])
         if this_device['publish_attributes']
           for output_key:output_map.keys()


### PR DESCRIPTION
I wanted the alias specified in the config file to be the friendly name in HA to make things a little cleaner.

To do this, I use the alias specified directly as the friendly name, then derive the Entity ID from this by removing any spaces and converting to lowercase. 

This also has the side effect of supporting a custom Entity ID in the config file, if desired. 

