### PR TITLE
Limited Support for Polled Devices!!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BLErry v0.2.x - A BLE Gateway inside Tasmota32 using Berry
+# BLErry v0.2.2-dev - A BLE Gateway inside Tasmota32 using Berry
 
 Here's an intro video by @digiblur to get an idea of the how and why! **HOWEVER, setup has changed, gotten simpler, since this video, see below.** Make sure to check out the discussions below.
 
@@ -219,28 +219,29 @@ Final reminder, you must convert this yaml to json and save a `blerry_config.jso
 - Hop in the #blerry thread in the #tasmota channel of Digiblur's discord.
 - Add a rule which enables device restart on wifi disconnect such as `ON Wifi#Connected Do RuleTimer1 0 ENDON ON Wifi#Disconnected Do RuleTimer1 60 ENDON ON Rules#Timer=1 Do Restart 1 ENDON`
 
-## Supported Devices in BLErry v0.2.x
+## Supported Devices in BLErry v0.2.2-dev
 
 Please discuss any devices you would like supported [here](https://github.com/tony-fav/tasmota-blerry/discussions/22) as well as if you are working on supporting any device!
 
 ### Sensors
 
-| Driver Name         | Mac Example        | Description |
-| ------------------- | ------------------ | ----------- |
-| `"ATCpvvx"`         | `"A4C138XXXXXX"`   | Xiaomi sensors on ATC or pvvx firmware with "ATC1441" or "Custom" advertisement. |
-| `"GVH5074"`         | `"E33281XXXXXX"`   | Govee H5074. *Need H5051 packets to add support to this driver.* |
-| `"GVH5075"`         | `"A4C138XXXXXX"`   | Govee H5072, H5075, H5101, and H5102. |
-| `"GVH5182"`         | `"C33130XXXXXX/1"` | Govee H5182 two probe meat thermometer with display. Thanks carlthehaitian! |
-| `"GVH5183"`         | `"A4C138XXXXXX"`   | Govee H5183 single probe meat thermometer. |
-| `"GVH5184"`         | `"D03232XXXXXX/1"` | Govee H5184 four probe meat thermometer with display. Thanks ElksInNC! |
-| `"IBSTH2"`          | `"494208XXXXXX"`   | Inkbird IBSTH1 & IBSTH2 with and without humidity. |
-| `"ThermoPro_TP59"`  | `"487E48XXXXXX"`   | ThermoPro TP59. |
-| `"WoContact"`       | `"D4BD28XXXXXX/1"` | Switchbot contact sensor (also has motion, binary lux, and a button). |
-| `"WoPresence"`      | `"FC7CADXXXXXX/1"` | Switchbot motion sensor (also has binary lux). |
-| `"WoSensorTH"`      | `"D4E4A3XXXXXX/1"` | Switchbot temperature and humidity sensor (regular and plus). |
-| `"Xiaomi"`          | `"AABBCCDDEEFF"`   | ATC/PVVX sensor on Mi-Like Advertising and Xiaomi LYWSDCGQ. *Can be expanded to more sensors* |
-| `"dev"`             | `"AABBCCDDEEFF"`   | A driver for easy development that prints out received raw data. |
-
+| Driver Name          | Mac Example        | Description |
+| -------------------- | ------------------ | ----------- |
+| `"ATCpvvx"`          | `"A4C138XXXXXX"`   | Xiaomi sensors on ATC or pvvx firmware with "ATC1441" or "Custom" advertisement. |
+| `"GVH5074"`          | `"E33281XXXXXX"`   | Govee H5074. *Need H5051 packets to add support to this driver.* |
+| `"GVH5075"`          | `"A4C138XXXXXX"`   | Govee H5072, H5075, H5101, and H5102. |
+| `"GVH5182"`          | `"C33130XXXXXX/1"` | Govee H5182 two probe meat thermometer with display. Thanks carlthehaitian! |
+| `"GVH5183"`          | `"A4C138XXXXXX"`   | Govee H5183 single probe meat thermometer. |
+| `"GVH5184"`          | `"D03232XXXXXX/1"` | Govee H5184 four probe meat thermometer with display. Thanks ElksInNC! |
+| `"IBSTH2"`           | `"494208XXXXXX"`   | Inkbird IBSTH1 & IBSTH2 with and without humidity. |
+| `"ThermoPro_TP59"`   | `"487E48XXXXXX"`   | ThermoPro TP59. |
+| `"WoContact"`        | `"D4BD28XXXXXX/1"` | Switchbot contact sensor (also has motion, binary lux, and a button). |
+| `"WoPresence"`       | `"FC7CADXXXXXX/1"` | Switchbot motion sensor (also has binary lux). |
+| `"WoSensorTH"`       | `"D4E4A3XXXXXX/1"` | Switchbot temperature and humidity sensor (regular and plus). |
+| `"Xiaomi"`           | `"AABBCCDDEEFF"`   | ATC/PVVX sensor on Mi-Like Advertising, Xiaomi LYWSDCGQ, Mi-Flora. *Can be expanded to more sensors* |
+| `"dev"`              | `"AABBCCDDEEFF"`   | A driver for easy development that prints out received raw data. |
+| -- POLLED DEVICES -- |                    | Devices which require a BLEOp command to receive a Notification with data.|
+| `WP6003`             | `"600303AABBCC"`   | WP6003 Air Box. |
 ## Development Status
 
 I *have* the following devices that I am seeking to support which all require some control:

--- a/blerry/blerry.be
+++ b/blerry/blerry.be
@@ -6,7 +6,7 @@
 # Provides MQTT Discovery and Reporting for BLE Devices
 #######################################################################
 
-var blerry_version = 'v0.2.1-dev'
+var blerry_version = 'v0.2.2-dev'
 
 # TODO
 #   Conform Govee Meat Thermometer Sensor Names across the 3 Devices
@@ -412,6 +412,7 @@ class Blerry_Device
       'GVH5182'         : 'blerry_driver_GVH5184.be',
       'GVH5183'         : 'blerry_driver_GVH5183.be',
       'GVH5184'         : 'blerry_driver_GVH5184.be',
+      'WP6003'          : 'blerry_driver_WP6003.be',
     }
     var fn = model_drivers[self.config['model']]    
     blerry_handle = def () return nil end
@@ -472,6 +473,12 @@ class Blerry_Device
     elif self.sensors[name].value != value
       self.sensors[name] = Blerry_Sensor(name, value, dev_cla, unit_of_meas)
       self.publish_available = true
+    end
+  end
+
+  def add_true_sensor(name, value, dev_cla, unit_of_meas)
+    if value
+      self.add_sensor(name, value, dev_cla, unit_of_meas)
     end
   end
 
@@ -930,7 +937,7 @@ class Blerry_Driver : Driver
       var c = d.op_cmd(d.mac)
       if c
         tasmota.cmd(c)
-        self.next_poll = tasmota.millis(30000)
+        self.next_poll = tasmota.millis(60000)
       end
     end
 

--- a/blerry/drivers/blerry_driver_WP6003.be
+++ b/blerry/drivers/blerry_driver_WP6003.be
@@ -1,15 +1,26 @@
 def blerry_op_handle(device, value)
   if value['state'] == 'DONENOTIFIED'
     var data = bytes(value['notify'])
+    device.add_attribute('FailCount', 0)
     if data[0] == 0x0A
-      device.add_sensor('Temperature', data.geti(6, -2)/10.0,  'temperature', '°C')
-      device.add_sensor('TVOC', data.get(10, -2)/1000.0,  'volatile_organic_compounds', 'ppm')
-      device.add_sensor('HCHO', data.get(12, -2)/1000.0,  nil, 'ppm')
-      device.add_sensor('CO2', data.get(16, -2),  'carbon_dioxide', 'ppm')
+      device.add_true_sensor('Temperature', data.geti(6, -2)/10.0, 'temperature', '°C')
+      device.add_true_sensor('TVOC', data.get(10, -2),  'volatile_organic_compounds', 'ppb')
+      device.add_true_sensor('HCHO', data.get(12, -2),  nil, 'ppb')
+      device.add_true_sensor('CO2', data.get(16, -2),  'carbon_dioxide', 'ppm')
+    end
+  else
+    var cnt = device.get_attribute('FailCount')
+    if cnt
+      device.add_attribute('FailCount', cnt.value+1)
+    else
+      device.add_attribute('FailCount', 1)
     end
   end
+  device.add_sensor('OpState', value['state'], nil, '')
+  device.add_sensor('OpFailureCount', device.get_attribute('FailCount').value, nil, '')
 end
 
 def blerry_op_cmd(mac)
   return string.format('BLEOp1 m:%s s:fff0 c:fff1 n:fff4 w:ab go', mac)
 end
+print('BLY: Driver: WP6003 Loaded')

--- a/blerry/drivers/blerry_driver_WP6003.be
+++ b/blerry/drivers/blerry_driver_WP6003.be
@@ -1,0 +1,15 @@
+def blerry_op_handle(device, value)
+  if value['state'] == 'DONENOTIFIED'
+    var data = bytes(value['notify'])
+    if data[0] == 0x0A
+      device.add_sensor('Temperature', data.geti(6, -2)/10.0,  'temperature', '°C')
+      device.add_sensor('TVOC', data.get(10, -2)/1000.0,  'volatile_organic_compounds', 'ppm')
+      device.add_sensor('HCHO', data.get(12, -2)/1000.0,  nil, 'ppm')
+      device.add_sensor('CO2', data.get(16, -2),  'carbon_dioxide', 'ppm')
+    end
+  end
+end
+
+def blerry_op_cmd(mac)
+  return string.format('BLEOp1 m:%s s:fff0 c:fff1 n:fff4 w:ab go', mac)
+end


### PR DESCRIPTION
These are devices that can be polled for data with a single BLEOp command returning on a notification characteristic: `BLEOp1 m:<mac> s:<service> c:<writechar> n:<notifychar> w:<bytestowrite> go`

First supported device is the WP6003 Air Box. Polling occurs every minute and cycles through polled devices registered. The Air Box is fairly inconsistent to respond on the notification before Tasmota times out the connection, but it does work regularly in my testing.