### PR TITLE
Add new driver WoSensorTHO to support SwitchBot Indoor/Outdoor Sensor

### DIFF
--- a/blerry/blerry.be
+++ b/blerry/blerry.be
@@ -465,6 +465,7 @@ class Blerry_Device
       'WoHand'          : 'blerry_driver_WoHand.be',
       'WoPresence'      : 'blerry_driver_WoPresence.be',
       'WoSensorTH'      : 'blerry_driver_WoSensorTH.be',
+      'WoSensorTHO'     : 'blerry_driver_WoSensorTHO.be',
       'GVH5182'         : 'blerry_driver_GVH5184.be',
       'GVH5183'         : 'blerry_driver_GVH5183.be',
       'GVH5184'         : 'blerry_driver_GVH5184.be',

--- a/blerry/blerry_setup.be
+++ b/blerry/blerry_setup.be
@@ -38,6 +38,7 @@ def blerry_remove_files()
     'blerry_driver_WoContact.be',
     'blerry_driver_WoPresence.be',
     'blerry_driver_WoSensorTH.be',
+    'blerry_driver_WoSensorTHO.be',
     'blerry_driver_GVH5182.be',
     'blerry_driver_GVH5183.be',
     'blerry_driver_GVH5184.be',

--- a/blerry/drivers/blerry_driver_WoSensorTHO.be
+++ b/blerry/drivers/blerry_driver_WoSensorTHO.be
@@ -1,0 +1,32 @@
+# SwitchBot Indoor/Outdoor Thermo-Hygrometer
+# https://us.switch-bot.com/products/switchbot-indoor-outdoor-thermo-hygrometer
+# Model: W3400010
+# https://github.com/OpenWonderLabs/SwitchBotAPI-BLE/issues/26#issuecomment-1585525955
+def blerry_handle(device, advert)
+  var elements = advert.get_elements_by_type_length(0xFF, 0x0F)
+  if size(elements)
+    var data = elements[0].data
+    # Assumption that the leading 69 is significant.
+    if data[0] != 0x69
+        return false
+    end
+    device.add_attribute('DevID', 'WoSensorTHO')
+    var t = ((data[10] & 0x0F) * 0.1 + (data[11] & 0x7F))
+    if (data[11]&0x80) == 0
+      t = -1 * t
+    end
+    var h = data[12] & 0x7F
+    var dewp = blerry_helpers.get_dewpoint(t, h)
+    device.add_sensor('Temperature', t,  'temperature', '°C')
+    device.add_sensor('Humidity', h, 'humidity', '%')
+    device.add_sensor('DewPoint', dewp, 'temperature', '°C')
+  end
+  elements = advert.get_elements_by_type_length(0x16, 0x06)
+  if size(elements)
+    var data = elements[0].data
+    device.add_sensor('Battery', data[4] & 0x7F, 'battery', '%')
+  end
+  return true
+end
+blerry_active = true
+print('BLY: Driver: WoSensorTHO Loaded')


### PR DESCRIPTION
Add new Driver WoSensorTHO for the SwitchBot Indoor/Outdoor Thermo-Hygrometer

Device Homepage: https://us.switch-bot.com/products/switchbot-indoor-outdoor-thermo-hygrometer
Device Model: W3400010

The official BLE API doesn't contain information for this device yet, but @vostok92 was able to decode it in
https://github.com/OpenWonderLabs/SwitchBotAPI-BLE/issues/26#issuecomment-1585525955