### PR TITLE
use first 12 bytes of mac to fix "BRY: Exception> 'key_error' - F98336xxxxxx/1"

### DIFF
--- a/blerry/blerry.be
+++ b/blerry/blerry.be
@@ -896,8 +896,16 @@ class Blerry
 
   def handle_BLE_packet(value, trigger, msg)
     var advert = BLE_AdvData(bytes(value['p']))
+    var mac = string.split(value['mac'], 12)[0]
+    var device
     try
-      var device = self.devices[value['mac']]
+      device = self.devices[mac]
+    except .. as e, m
+      print('BLY: tried to get device with mac =', mac, 'and alias =', value['a'])
+      print(self.devices)
+      raise e, m
+    end
+    try
       # device.handle(device, advert)
       var handle_f = device.handle
       handle_f(device, advert)
@@ -907,7 +915,7 @@ class Blerry
         device.publish_available = true
       end
     except .. as e, m
-      print('BLY: tried to handle mac =', value['mac'], 'with alias =', value['a'])
+      print('BLY: tried to handle mac =', mac, 'with alias =', value['a'])
       raise e, m
     end
   end


### PR DESCRIPTION
I tried to use the WoSensorTHO driver with Tasmota 13.2.0(bluetooth), which did not work, giving the type of error message in the title. The MAC gets a spurious "/1" tacked on, causing the key_error.  (I don't get this error with the GVH5075 devices I have, so this is mysterious.) This hack just lops off anything after 12 bytes. The Berry language is a bit foreign to me, so I didn't go beyond solving my problem. Surely the true fix is somewhere else, but this works and should be harmless to all other devices. I left debugging code in here that you'll probably want to delete. Hope this is helpful.