### PR TITLE
fix BTHome for irregular devices

### DIFF
--- a/blerry/drivers/blerry_driver_BTHome.be
+++ b/blerry/drivers/blerry_driver_BTHome.be
@@ -57,7 +57,7 @@ def blerry_handle(device, advert)
     elements = advert.get_elements_by_type_data(0x16, bytes('D2FC'), 0)
     if size(elements)
       var ad=elements[0].data[2];
-      if ad!=0x40 #not an V2 unencripted
+      if ad&0xC1!=0x40 #not an V2 unencripted
         return false
       end
       var Meas_Types = {


### PR DESCRIPTION
Only check the relevant bits of the BTHome device information.
Otherwise irregular devices, for example shelly Motion BLU which have a flag of 0x44 do not get parsed.